### PR TITLE
Add ORG= variable so the org can be entirely elsewhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,19 @@ OPTIONS=
 
 #
 # figure out the inventory.
-#  - if INVENTORY is given from the command line or env, just use it
+#  - if ORG is given from the command line or env, set INVENTORY to
+#    ${ORG}/inventory and CATALOG to ${ORG}/catalog
+#  - Otherwise, if INVENTORY is given from the command line or env, just use it
 #    (and use CATALOG)
 #  - Otherwise, if there's a hosts file in this directory, use it
 #  - Otherwise, if there's a directory ../inventory, use it
 #  - Otherwise complain and quit.
 #
+ifneq ($(ORG),)
+ INVENTORY=${ORG}/inventory
+ CATALOG=${ORG}/catalog
+endif
+
 ifeq ($(INVENTORY),)
  ifneq ($(wildcard hosts),)
    INVENTORY=hosts
@@ -52,9 +59,7 @@ ifeq ($(INVENTORY),)
    $(error Can't find an inventory file)
  endif
 else
- ifeq ($(wildcard $(INVENTORY)/.),)
-   $(error not a directory: $(INVENTORY))
- else ifeq ($(CATALOG),)
+ ifeq ($(CATALOG),)
    ifneq ($(wildcard $(dir $(INVENTORY))/catalog/.),)
      CATALOG=$(dir $(INVENTORY))
    else
@@ -63,7 +68,10 @@ else
  endif
 endif
 
-# another idiot check.
+# santity checks.
+ifeq ($(wildcard $(INVENTORY)/.),)
+   $(error not a directory: $(INVENTORY))
+endif
 ifeq ($(wildcard $(CATALOG)/.),)
    $(error not a directory: $(CATALOG))
 endif


### PR DESCRIPTION
This change adds 

- ability to run automatically when ttn-multitech-cm is a submodule of the organization database (using the data from the organization), and
- the (even better) ability to point ttn-muilttech-cm at an external organization database, using `ORG={dir}`.

It would be very helpful to have both forms, though the submodule form probably needs to be deprecated (and can easily be achieved with `ORG=..` after we remove the automatic version).

Note: the reason for deprecating automatic submodules is that I've found that having multiple copies of the repo around, while trying to track development, is painful; though for production once things get more final it may well be better (as it ties the database to a specific version). 